### PR TITLE
Update version numbers

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,7 +27,7 @@ dependencies:
     - pillow
     - requests
     - imjoy
-    - imjoy-rpc>=0.2.5
+    - imjoy-rpc
     - imjoy-jupyter-extension
     - imjoy-elfinder
     - jupyter-server-proxy

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.11.4
+  - python
   - pip
   - numpy
   - scipy

--- a/environment.yml
+++ b/environment.yml
@@ -17,8 +17,8 @@ dependencies:
   - scikit-image
   - scyjava
   - xarray
-  - matplotlib=3.2
-  - pyvirtualdisplay=0.2
+  - matplotlib
+  - pyvirtualdisplay
   - pyimagej
   - pip:
     - scikit-image

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
   - defaults
 dependencies:
-  - python=3.7.7
+  - python=3.11.4
   - pip
   - numpy
   - scipy
@@ -19,7 +19,7 @@ dependencies:
   - xarray
   - matplotlib=3.2
   - pyvirtualdisplay=0.2
-  - pyimagej=1.0.0
+  - pyimagej
   - pip:
     - scikit-image
     - scikit-learn

--- a/postBuild
+++ b/postBuild
@@ -1,5 +1,5 @@
 export JAVA_HOME=/srv/conda/envs/notebook
-wget https://downloads.imagej.net/fiji/archive/20201104-1356/fiji-linux64.zip
+wget https://downloads.imagej.net/fiji/archive/20221201-1017/fiji-linux64.zip
 unzip fiji-linux64.zip -d $HOME
 # fix FilamentDetector issue
 mv $HOME/Fiji.app/jars/FilamentDetector-1.0.0.jar $HOME/Fiji.app/jars/FilamentDetector-1.0.0.jar.disabled


### PR DESCRIPTION
Removed pyimagej version number as version 1.0.0 has bugs causing issues like the one mentioned in the post at [image.sc forum](https://forum.image.sc/t/replaces-the-image-with-the-specified-imageplus-in-pyimagej/57438/4)

Updated Fiji and other Python dependencies' version numbers

